### PR TITLE
URL Generation Changed

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -2,3 +2,6 @@ package goxford
 
 //AuthHeader is the header name for authorizing with Project Oxford APIs.
 const AuthHeader string = "Ocp-Apim-Subscription-Key"
+
+// BaseURL is the base URl for the Project Oxford API.
+const BaseURL string = "https://api.projectoxford.ai"


### PR DESCRIPTION
This PR adds a BaseURL to the constants.go file which points to the base URL for the Project Oxford API. Each API struct (e.g. Face, Voice, etc) will be responsible for generating the "base" URL for those endpoints respectively.

There's still a lot of URL configuration within the actual functions themselves and I don't think I'm crazy about that. Need to look into setting up some kind of config data structure initially to see if that would make future API changes easier to handle (e.g. it seems like HTTP verbs and URLs have definitely changed in the past).
